### PR TITLE
Include test files so test suite passes from PyPi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include puremagic/*.json
 include LICENSE
 include AUTHORS.rst
 include CHANGELOG.md
+graft test
+global-exclude *.py[cod]


### PR DESCRIPTION
I've submitted puremagic to the FreeBSD ports tree - see FreeBSD report https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=258593

While generating the port, I noticed that the package distributed from PyPi is missing the test data files so the test suite will always fail if the source is fetched from there. The python test file (test_common_extensions.py) gets pulled into the python package because it has a .py extension, but the data files the tests run against are missed because they do not.

This commit grafts in test/ (pulls in everything) and then excludes pyc, pyo & pyd files per the recommended way of doing this in the python packaging manual.

FreeBSD preference is to pull all python packages from PyPi and to include test-suites where available. For right now, the options are either omit the test suite or pull from GitHub.