### PR TITLE
Reset stream cursor after read

### DIFF
--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -168,6 +168,7 @@ def _stream_details(stream):
     head = stream.read(max_head)
     stream.seek(-max_foot, os.SEEK_END)
     foot = stream.read()
+    stream.seek(0)
     return head, foot
 
 


### PR DESCRIPTION
I was facing this weird issue where downloading a previously uploaded PDF resulted in chrome complaining about not being able to open the document. Figured out what the actual issue was after comparing the original to the downloaded file which was missing the initial `%PDF-`. Manually resetting the stream worked but it would be nice to have puremagic do this automatically.