### PR TITLE
Update magic_data.json with .jxl

### DIFF
--- a/puremagic/magic_data.json
+++ b/puremagic/magic_data.json
@@ -99,6 +99,8 @@
         ["3c2f7376673e", -6, ".svg", "image/svg+xml", "Scalable Vector Graphics Image"]
     ],
     "headers": [
+	["ff0a", 0, ".jxl", "image/jxl", "JPEG XL image (Raw stream)"],
+	["0000000c4a584c200d0a870a", 0, ".jxl", "image/jxl", "JPEG XL image (ISOBMFF container)"],
         ["3c3f786d6c", 0, ".xml", "application/xml", "XML Document"],
         ["454c46", 1, ".AppImage", "application/x-iso9660-appimage", "AppImage application bundle"],
         ["4341434845204d414e4946455354", 0, ".manifest", "text/cache-manifest", "Web application cache manifest"],


### PR DESCRIPTION
Closes #48

Added .jxl filetypes per official specs at:
https://jpegxl.info/
https://github.com/libjxl/libjxl/blob/main/doc/format_overview.md
https://en.wikipedia.org/wiki/JPEG_XL

Raw test files `FF 0A`:  [jxl.zip](https://github.com/cdgriffith/puremagic/files/14383989/jxl.zip)
- JXL logo (Raw Data) extracted from [https://jpegxl.info/jxl-art.html](https://jpegxl.info/jxl-art.html)
- JXL logo (Exported from GIMP) as above but loaded and saved back out in GIMP
- kungfubaby convert from animated gif using [libjxl's cjxl](https://github.com/libjxl/libjxl/releases)

ISOBMFF test file `0000000c4a584c200d0a870a`:
I found one and only one so far (I spent a long time looking) at https://github.com/Exiv2/exiv2/issues/1503#issuecomment-803943178 big thanks 👏 to @kmilos for making one.
