### PR TITLE
Update magic_data.json with JPEG XS

### DIFF
--- a/puremagic/magic_data.json
+++ b/puremagic/magic_data.json
@@ -50,7 +50,10 @@
         ["", 0, ".ts", "application/x-typescript", "Transport Stream File"],
         ["", 0, ".tsx", "application/x-typescript", "Typescript File"],
         ["", 0, ".pickle", "", "Python Pickle File"],
-        ["", 0, ".conf", "text/plain", "Configuration File"]
+        ["", 0, ".conf", "text/plain", "Configuration File"],
+	["", 0, ".jxsi", "image/jxsi", "JPEG XS image"],
+	["", 0, ".jxss", "image/jxss", "JPEG XS image"],
+	["", 0, ".jxsv", "video/jxsv", "JPEG XS video"]
     ],
     "multi-part-headers": {
         "464f524d": [
@@ -1330,6 +1333,8 @@
         ["6674797068656973", 4, ".heic", "image/heic", "HEIC Image format (HEIS scalable)"],
         ["667479706865696d", 4, ".heic", "image/heic", "HEIC Image format (HEIM multiview)"],
         ["667479706865766d", 4, ".heic", "image/heic", "HEIC Animated Image format (HEIM multiview)"],
-        ["6674797068657673", 4, ".heic", "image/heic", "HEIC Animated Image format (HEIS scalable)"]
+        ["6674797068657673", 4, ".heic", "image/heic", "HEIC Animated Image format (HEIS scalable)"],
+	["0000000c4a5853200d0a870a", 0, ".jxs", "image/jxs", "JPEG XS image"],
+	["ff10ff50", 0, ".jxsc", "image/jxsc", "JPEG XS codestream"]
     ]
 }


### PR DESCRIPTION
Closes #52 

JPEG XS Image and Video formats added. It's an odd format that seems to have a few variants and some conflicting info. Entries are derived from:

- https://www.loc.gov/preservation/digital/formats/fdd/fdd000545.shtml?loclr=blogsig
- https://en.wikipedia.org/wiki/JPEG_XS
- https://jpeg.org/jpegxs/

I've added some samples as well as the orignal AI prompt generated .jpg and .ppm file that will work with the reference software encoder (the docs say you can use raw as well but this seems too not be the case). The `.jxs` files included (which actually should be `.jxsc` according to the official specs) have slight variances in the header area from playing with different encoder settings, but the `0xff10ff50` remains a constant.
[JPEG XS Samples.zip](https://github.com/cdgriffith/puremagic/files/14418064/JPEG.XS.Samples.zip)

Other variants including the video have been added as extensions only for now. If in the future samples become available there may be an option to define a fingerprint for them.
