### PR TITLE
Multi part reverse lookup

### DIFF
--- a/puremagic/magic_data.json
+++ b/puremagic/magic_data.json
@@ -89,6 +89,15 @@
         "52494658": [
             ["4647444d", 8, ".dcr", "", "Adobe Shockwave"],
             ["4d563933", 8, ".dir", "", "Macromedia Director file format"]
+        ],
+	"4352454d" : [
+		["444f4e4500000000", -8, ".ctm", "", "CreamTracker module"]				
+        ],
+	"3c747261636b206e616d653d22" : [
+		["3c2f747261636b3e0a", -9, ".pt2", "", "PicaTune 2 module"]				
+        ],
+	"3c6d6c74" : [
+		["3c2f6d6c743e0a", -7, ".mlt", "", "Shotcut project"]				
         ]
     },
     "footers": [
@@ -1330,6 +1339,9 @@
         ["6674797068656973", 4, ".heic", "image/heic", "HEIC Image format (HEIS scalable)"],
         ["667479706865696d", 4, ".heic", "image/heic", "HEIC Image format (HEIM multiview)"],
         ["667479706865766d", 4, ".heic", "image/heic", "HEIC Animated Image format (HEIM multiview)"],
-        ["6674797068657673", 4, ".heic", "image/heic", "HEIC Animated Image format (HEIS scalable)"]
+        ["6674797068657673", 4, ".heic", "image/heic", "HEIC Animated Image format (HEIS scalable)"],
+	["4352454D", 44, ".ctm", "", "CreamTracker module"],
+	["3c747261636b206e616d653d22", 0, ".pt2", "", "PicaTune 2 module"], 
+	["3c6d6c74", 38, ".mlt", "", "Shotcut project"]    
     ]
 }

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -151,9 +151,7 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
     for matched in matches:
         if matched.byte_match in multi_part_header_dict:
             for magic_row in multi_part_header_dict[matched.byte_match]:
-                if "-" in str(magic_row.offset):
-                    start = magic_row.offset
-                    end = magic_row.offset + len(magic_row.byte_match)
+            if magic_row.offset < 0:
                     match_area = footer[start:end] if end != 0 else footer[start:]
                     if match_area == magic_row.byte_match:
                         new_matches.add(
@@ -166,8 +164,6 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
                             )
                         )
                 else:
-                    start = magic_row.offset
-                    end = magic_row.offset + len(magic_row.byte_match)
                     if end > len(header):
                         continue
                     if header[start:end] == magic_row.byte_match:

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -151,7 +151,9 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
     for matched in matches:
         if matched.byte_match in multi_part_header_dict:
             for magic_row in multi_part_header_dict[matched.byte_match]:
-            if magic_row.offset < 0:
+                start = magic_row.offset
+                end = magic_row.offset + len(magic_row.byte_match)
+                if magic_row.offset < 0:
                     match_area = footer[start:end] if end != 0 else footer[start:]
                     if match_area == magic_row.byte_match:
                         new_matches.add(

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -162,7 +162,8 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
                                 offset=magic_row.offset,
                                 extension=magic_row.extension,
                                 mime_type=magic_row.mime_type,
-                                name=magic_row.name, )
+                                name=magic_row.name,
+                            )
                     )   
                 else:           
                     start = magic_row.offset

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -151,20 +151,34 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
     for matched in matches:
         if matched.byte_match in multi_part_header_dict:
             for magic_row in multi_part_header_dict[matched.byte_match]:
-                start = magic_row.offset
-                end = magic_row.offset + len(magic_row.byte_match)
-                if end > len(header):
-                    continue
-                if header[start:end] == magic_row.byte_match:
-                    new_matches.add(
-                        PureMagic(
-                            byte_match=header[matched.offset : end],
-                            offset=magic_row.offset,
-                            extension=magic_row.extension,
-                            mime_type=magic_row.mime_type,
-                            name=magic_row.name,
+                if '-' in str(magic_row.offset):
+                    start = magic_row.offset
+                    end = magic_row.offset + len(magic_row.byte_match)
+                    match_area = footer[start:end] if end != 0 else footer[start:]
+                    if match_area == magic_row.byte_match:
+                        new_matches.add(
+                            PureMagic(
+                                byte_match=matched.byte_match + magic_row.byte_match, 
+                                offset=magic_row.offset,
+                                extension=magic_row.extension,
+                                mime_type=magic_row.mime_type,
+                                name=magic_row.name, )
+                    )   
+                else:           
+                    start = magic_row.offset
+                    end = magic_row.offset + len(magic_row.byte_match)
+                    if end > len(header):
+                        continue
+                    if header[start:end] == magic_row.byte_match:
+                        new_matches.add(
+                            PureMagic(
+                                byte_match=header[matched.offset : end],
+                                offset=magic_row.offset,
+                                extension=magic_row.extension,
+                                mime_type=magic_row.mime_type,
+                                name=magic_row.name,
                         )
-                    )
+                    )   
 
     matches.extend(list(new_matches))
     return _confidence(matches, ext)

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -151,21 +151,21 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
     for matched in matches:
         if matched.byte_match in multi_part_header_dict:
             for magic_row in multi_part_header_dict[matched.byte_match]:
-                if '-' in str(magic_row.offset):
+                if "-" in str(magic_row.offset):
                     start = magic_row.offset
                     end = magic_row.offset + len(magic_row.byte_match)
                     match_area = footer[start:end] if end != 0 else footer[start:]
                     if match_area == magic_row.byte_match:
                         new_matches.add(
                             PureMagic(
-                                byte_match=matched.byte_match + magic_row.byte_match, 
+                                byte_match=matched.byte_match + magic_row.byte_match,
                                 offset=magic_row.offset,
                                 extension=magic_row.extension,
                                 mime_type=magic_row.mime_type,
                                 name=magic_row.name,
                             )
-                    )   
-                else:           
+                        )
+                else:
                     start = magic_row.offset
                     end = magic_row.offset + len(magic_row.byte_match)
                     if end > len(header):
@@ -178,8 +178,8 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
                                 extension=magic_row.extension,
                                 mime_type=magic_row.mime_type,
                                 name=magic_row.name,
+                            )
                         )
-                    )   
 
     matches.extend(list(new_matches))
     return _confidence(matches, ext)


### PR DESCRIPTION
Closes #57

While digging through files for PR #58 I discovered that we could do with a `footer` style reverse lookup on the multi part match to help boost confidence scores (especially if the footer is small as well). This modifies the multiple match to allow reverse looksup.

To behave like the normal forward match, we aggregate the `matched.byte_match` and `magic_row.byte_match` to provide a longer match to the `_confidence` function. One downside of the is that in the match data it will report the two matches smooshed together, e.g.:

- `.mlt` is `0x3c6d6c74` / `<mlt` (0.4) and `3c2f6d6c743e0a` / `</mlt>\n` (0,7), combined confidence of 0.8 but you'll see `<mlt</mlt>\n` in the data which looks untidy (could there be a better way to address this)

Also, some unexpected results:

- `.pt2` cannot score above 0.8 when combined, I imagine it's because both are long matches which score 0.8 individually
- `.ct` gets 0.4 for `CREM` and 0.8 for `DONE    ` but the combined will not go above 0.8

[Sample files.zip](https://github.com/cdgriffith/puremagic/files/14473664/Sample.files.zip)

Any improvements/comments are welcome, it works but there might be a better, nicer looking way to handle this.

## New entries for magic_data.json:

- Shotcut `.mlt` opensource video editor 
- Creamtracker `.ct`: Tracker format from the creator of BeRo Tracker [BeRo's Blog](https://blog.rosseaux.net/), under Audio software
- Picatune 2 `.pt2`: Another music format from the creator of BeRo Tracker [Picatune 2](https://blog.rosseaux.net/page/3ab0ca3a73a47c2f47bc3735fdc29794/Picatune_2)
