### PR TITLE
Update main.py to resolve PYTHONWARNDEFAULTENCODING

### DIFF
--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -73,7 +73,7 @@ def _magic_data(
     Dict[bytes, List[PureMagic]],
 ]:
     """Read the magic file"""
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         data = json.load(f)
     headers = sorted((_create_puremagic(x) for x in data["headers"]), key=lambda x: x.byte_match)
     footers = sorted((_create_puremagic(x) for x in data["footers"]), key=lambda x: x.byte_match)


### PR DESCRIPTION
Closes #60 

Adds `encoding="utf-8"` to line 76 to resolve PYTHONWARNDEFAULTENCODING warning. Per the following:
- [https://peps.python.org/pep-0597/](https://peps.python.org/pep-0597/)
- [https://github.com/numpy/numpy/issues/24115](https://github.com/numpy/numpy/issues/24115)

It's something added in to Python 3.10 to help ensure text-based files are treated as UTF-8 for broader cross-platform compatibility. After Python 3.15 `encoding="utf-8"` will become the default, but leaving it in the code will not cause any issues.

Tested under windows by using `set PYTHONWARNDEFAULTENCODING=1` before running, no errors appeared so should all be good.