### PR TITLE
2024 05 04 Experimental regex support (No rush to merge, proof of concept/feasibility discussion)

### DIFF
--- a/puremagic/magic_data.json
+++ b/puremagic/magic_data.json
@@ -373,7 +373,12 @@
   		["57505542", 10, ".mp3", "audio/mpeg", "MPEG-1 Audio Layer 3 (MP3) ID3v2.4.0 audio file"],
   		["57585858", 10, ".mp3", "audio/mpeg", "MPEG-1 Audio Layer 3 (MP3) ID3v2.4.0 audio file"],
   		["544147", -128, ".mp3", "audio/mpeg", "MPEG-1 Audio Layer 3 (MP3) ID3v2.4.0 audio file"]
-  	]
+  	],
+	"504b030414000600" : [
+	  ["776f72642f646f63756d656e742e786d6c", 3000, ".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "###REGEX### MS Office Open XML Format Word Document"],
+	  ["786c2f776f726b626f6f6b2e786d6c", 3000, ".xlsx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "###REGEX### Microsoft Office 2007+ Open XML Format Excel Document file"],
+	  ["786c2f76626150726f6a6563742e62696e", 0, ".xlsm", "application/vnd.ms-excel.sheet.macroEnabled.12","###REGEX### Microsoft Excel - Macro-Enabled Workbook"]
+	]
   },
   "footers": [
     ["54525545564953494f4e2d5846494c452e00", -18, ".tga", "image/tga", "Truevision Targa Graphic file"],
@@ -447,7 +452,7 @@
     ["464f524d", 0, ".aiff", "audio/aiff", "Audio Interchange File"],
     ["2e524d46", 0, ".rmvb", "", "RealMedia streaming media"],
     [
-      "504b0304", 0, ".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "504b030414000600", 0, ".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "MS Office Open XML Format Document"
     ],
     [
@@ -496,7 +501,7 @@
       "Microsoft PowerPoint - Macro-Enabled Template File"
     ],
     [
-      "504b0304", 0, ".xlsm", "application/vnd.ms-excel.sheet.macroEnabled.12",
+      "504b030414000600", 0, ".xlsm", "application/vnd.ms-excel.sheet.macroEnabled.12",
       "Microsoft Excel - Macro-Enabled Workbook"
     ],
     ["7a626578", 0, ".info", "", "ZoomBrowser Image Index"],

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -75,8 +75,12 @@ def _magic_data(
     """Read the magic file"""
     with open(filename, encoding="utf-8") as f:
         data = json.load(f)
-    headers = sorted((_create_puremagic(x) for x in data["headers"]), key=lambda x: x.byte_match)
-    footers = sorted((_create_puremagic(x) for x in data["footers"]), key=lambda x: x.byte_match)
+    headers = sorted(
+        (_create_puremagic(x) for x in data["headers"]), key=lambda x: x.byte_match
+    )
+    footers = sorted(
+        (_create_puremagic(x) for x in data["footers"]), key=lambda x: x.byte_match
+    )
     extensions = [_create_puremagic(x) for x in data["extension_only"]]
     multi_part_extensions = {}
     for file_match, option_list in data["multi-part"].items():
@@ -96,20 +100,28 @@ def _create_puremagic(x: List) -> PureMagic:
     )
 
 
-magic_header_array, magic_footer_array, extension_only_array, multi_part_dict = _magic_data()
+magic_header_array, magic_footer_array, extension_only_array, multi_part_dict = (
+    _magic_data()
+)
 
 
 def _max_lengths() -> Tuple[int, int]:
     """The length of the largest magic string + its offset"""
     max_header_length = max([len(x.byte_match) + x.offset for x in magic_header_array])
-    max_footer_length = max([len(x.byte_match) + abs(x.offset) for x in magic_footer_array])
+    max_footer_length = max(
+        [len(x.byte_match) + abs(x.offset) for x in magic_footer_array]
+    )
 
     for options in multi_part_dict.values():
         for option in options:
             if option.offset < 0:
-                max_footer_length = max(max_footer_length, len(option.byte_match) + abs(option.offset))
+                max_footer_length = max(
+                    max_footer_length, len(option.byte_match) + abs(option.offset)
+                )
             else:
-                max_header_length = max(max_header_length, len(option.byte_match) + option.offset)
+                max_header_length = max(
+                    max_header_length, len(option.byte_match) + option.offset
+                )
 
     return max_header_length, max_footer_length
 
@@ -118,7 +130,11 @@ def _confidence(matches, ext=None) -> List[PureMagicWithConfidence]:
     """Rough confidence based on string length and file extension"""
     results = []
     for match in matches:
-        con = 0.8 if len(match.byte_match) >= 9 else float("0.{0}".format(len(match.byte_match)))
+        con = (
+            0.8
+            if len(match.byte_match) >= 9
+            else float("0.{0}".format(len(match.byte_match)))
+        )
         if con >= 0.1 and ext and ext == match.extension:
             con = 0.9
         results.append(PureMagicWithConfidence(confidence=con, **match._asdict()))
@@ -126,7 +142,9 @@ def _confidence(matches, ext=None) -> List[PureMagicWithConfidence]:
     if not results and ext:
         for magic_row in extension_only_array:
             if ext == magic_row.extension:
-                results.append(PureMagicWithConfidence(confidence=0.1, **magic_row._asdict()))
+                results.append(
+                    PureMagicWithConfidence(confidence=0.1, **magic_row._asdict())
+                )
 
     if not results:
         raise PureError("Could not identify file")
@@ -134,7 +152,9 @@ def _confidence(matches, ext=None) -> List[PureMagicWithConfidence]:
     return sorted(results, key=lambda x: x.confidence, reverse=True)
 
 
-def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithConfidence]:
+def _identify_all(
+    header: bytes, footer: bytes, ext=None
+) -> List[PureMagicWithConfidence]:
     """Attempt to identify 'data' by its magic numbers"""
 
     # Capture the length of the data
@@ -288,7 +308,9 @@ def from_file(filename: Union[os.PathLike, str], mime: bool = False) -> str:
 
 
 def from_string(
-    string: Union[str, bytes], mime: bool = False, filename: Optional[Union[os.PathLike, str]] = None
+    string: Union[str, bytes],
+    mime: bool = False,
+    filename: Optional[Union[os.PathLike, str]] = None,
 ) -> str:
     """Reads in string, attempts to identify content based
     off magic number and will return the file extension.
@@ -307,7 +329,9 @@ def from_string(
     return _magic(head, foot, mime, ext)
 
 
-def from_stream(stream, mime: bool = False, filename: Optional[Union[os.PathLike, str]] = None) -> str:
+def from_stream(
+    stream, mime: bool = False, filename: Optional[Union[os.PathLike, str]] = None
+) -> str:
     """Reads in stream, attempts to identify content based
     off magic number and will return the file extension.
     If mime is True it will return the mime type instead.
@@ -342,7 +366,9 @@ def magic_file(filename: Union[os.PathLike, str]) -> List[PureMagicWithConfidenc
     return info
 
 
-def magic_string(string, filename: Optional[Union[os.PathLike, str]] = None) -> List[PureMagicWithConfidence]:
+def magic_string(
+    string, filename: Optional[Union[os.PathLike, str]] = None
+) -> List[PureMagicWithConfidence]:
     """
     Returns tuple of (num_of_matches, array_of_matches)
     arranged highest confidence match first
@@ -361,7 +387,9 @@ def magic_string(string, filename: Optional[Union[os.PathLike, str]] = None) -> 
     return info
 
 
-def magic_stream(stream, filename: Optional[Union[os.PathLike, str]] = None) -> List[PureMagicWithConfidence]:
+def magic_stream(
+    stream, filename: Optional[Union[os.PathLike, str]] = None
+) -> List[PureMagicWithConfidence]:
     """Returns tuple of (num_of_matches, array_of_matches)
     arranged highest confidence match first
     If filename is provided it will be used in the computation.

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -75,12 +75,8 @@ def _magic_data(
     """Read the magic file"""
     with open(filename, encoding="utf-8") as f:
         data = json.load(f)
-    headers = sorted(
-        (_create_puremagic(x) for x in data["headers"]), key=lambda x: x.byte_match
-    )
-    footers = sorted(
-        (_create_puremagic(x) for x in data["footers"]), key=lambda x: x.byte_match
-    )
+    headers = sorted((_create_puremagic(x) for x in data["headers"]), key=lambda x: x.byte_match)
+    footers = sorted((_create_puremagic(x) for x in data["footers"]), key=lambda x: x.byte_match)
     extensions = [_create_puremagic(x) for x in data["extension_only"]]
     multi_part_extensions = {}
     for file_match, option_list in data["multi-part"].items():
@@ -100,28 +96,20 @@ def _create_puremagic(x: List) -> PureMagic:
     )
 
 
-magic_header_array, magic_footer_array, extension_only_array, multi_part_dict = (
-    _magic_data()
-)
+magic_header_array, magic_footer_array, extension_only_array, multi_part_dict = _magic_data()
 
 
 def _max_lengths() -> Tuple[int, int]:
     """The length of the largest magic string + its offset"""
     max_header_length = max([len(x.byte_match) + x.offset for x in magic_header_array])
-    max_footer_length = max(
-        [len(x.byte_match) + abs(x.offset) for x in magic_footer_array]
-    )
+    max_footer_length = max([len(x.byte_match) + abs(x.offset) for x in magic_footer_array])
 
     for options in multi_part_dict.values():
         for option in options:
             if option.offset < 0:
-                max_footer_length = max(
-                    max_footer_length, len(option.byte_match) + abs(option.offset)
-                )
+                max_footer_length = max(max_footer_length, len(option.byte_match) + abs(option.offset))
             else:
-                max_header_length = max(
-                    max_header_length, len(option.byte_match) + option.offset
-                )
+                max_header_length = max(max_header_length, len(option.byte_match) + option.offset)
 
     return max_header_length, max_footer_length
 
@@ -130,11 +118,7 @@ def _confidence(matches, ext=None) -> List[PureMagicWithConfidence]:
     """Rough confidence based on string length and file extension"""
     results = []
     for match in matches:
-        con = (
-            0.8
-            if len(match.byte_match) >= 9
-            else float("0.{0}".format(len(match.byte_match)))
-        )
+        con = 0.8 if len(match.byte_match) >= 9 else float("0.{0}".format(len(match.byte_match)))
         if con >= 0.1 and ext and ext == match.extension:
             con = 0.9
         results.append(PureMagicWithConfidence(confidence=con, **match._asdict()))
@@ -142,9 +126,7 @@ def _confidence(matches, ext=None) -> List[PureMagicWithConfidence]:
     if not results and ext:
         for magic_row in extension_only_array:
             if ext == magic_row.extension:
-                results.append(
-                    PureMagicWithConfidence(confidence=0.1, **magic_row._asdict())
-                )
+                results.append(PureMagicWithConfidence(confidence=0.1, **magic_row._asdict()))
 
     if not results:
         raise PureError("Could not identify file")
@@ -152,9 +134,7 @@ def _confidence(matches, ext=None) -> List[PureMagicWithConfidence]:
     return sorted(results, key=lambda x: x.confidence, reverse=True)
 
 
-def _identify_all(
-    header: bytes, footer: bytes, ext=None
-) -> List[PureMagicWithConfidence]:
+def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithConfidence]:
     """Attempt to identify 'data' by its magic numbers"""
 
     # Capture the length of the data
@@ -204,8 +184,7 @@ def _identify_all(
                         if match_area == magic_row.byte_match:
                             new_matches.add(
                                 PureMagic(
-                                    byte_match=matched.byte_match
-                                    + magic_row.byte_match,
+                                    byte_match=matched.byte_match + magic_row.byte_match,
                                     offset=magic_row.offset,
                                     extension=magic_row.extension,
                                     mime_type=magic_row.mime_type,
@@ -305,9 +284,7 @@ def from_file(filename: Union[os.PathLike, str], mime: bool = False) -> str:
 
 
 def from_string(
-    string: Union[str, bytes],
-    mime: bool = False,
-    filename: Optional[Union[os.PathLike, str]] = None,
+    string: Union[str, bytes], mime: bool = False, filename: Optional[Union[os.PathLike, str]] = None
 ) -> str:
     """Reads in string, attempts to identify content based
     off magic number and will return the file extension.
@@ -326,9 +303,7 @@ def from_string(
     return _magic(head, foot, mime, ext)
 
 
-def from_stream(
-    stream, mime: bool = False, filename: Optional[Union[os.PathLike, str]] = None
-) -> str:
+def from_stream(stream, mime: bool = False, filename: Optional[Union[os.PathLike, str]] = None) -> str:
     """Reads in stream, attempts to identify content based
     off magic number and will return the file extension.
     If mime is True it will return the mime type instead.
@@ -363,9 +338,7 @@ def magic_file(filename: Union[os.PathLike, str]) -> List[PureMagicWithConfidenc
     return info
 
 
-def magic_string(
-    string, filename: Optional[Union[os.PathLike, str]] = None
-) -> List[PureMagicWithConfidence]:
+def magic_string(string, filename: Optional[Union[os.PathLike, str]] = None) -> List[PureMagicWithConfidence]:
     """
     Returns tuple of (num_of_matches, array_of_matches)
     arranged highest confidence match first
@@ -384,9 +357,7 @@ def magic_string(
     return info
 
 
-def magic_stream(
-    stream, filename: Optional[Union[os.PathLike, str]] = None
-) -> List[PureMagicWithConfidence]:
+def magic_stream(stream, filename: Optional[Union[os.PathLike, str]] = None) -> List[PureMagicWithConfidence]:
     """Returns tuple of (num_of_matches, array_of_matches)
     arranged highest confidence match first
     If filename is provided it will be used in the computation.

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -163,9 +163,11 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
                     import re
 
                     if not magic_row.offset == 0:
-                        scan_bytes = header[0 : magic_row.offset]  # We use .offset as amount of bytes from 0 to scan, saves opening whole file
+                        # We use .offset as amount of bytes from 0 to scan, saves opening whole file
+                        scan_bytes = header[0 : magic_row.offset]
                     else:
-                        scan_bytes = header  # We have no way to know where it will be in the file
+                        # We have no way to know where it will be in the file
+                        scan_bytes = header
                     if re.search(magic_row.byte_match, scan_bytes):
                         new_matches.add(
                             PureMagic(
@@ -173,7 +175,7 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
                                 offset=magic_row.offset,
                                 extension=magic_row.extension,
                                 mime_type=magic_row.mime_type,
-                                name=magic_row.name.split("###REGEX### ")[1],  # Strips ###REGEX### trigger from name
+                                name=magic_row.name.split("###REGEX### ")[1],
                             )
                         )
 

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -183,10 +183,8 @@ def _identify_all(
                     import re
 
                     if not magic_row.offset == 0:
-                        # We use .offset as amount of bytes from 0 to scan, saves opening whole file
                         scan_bytes = header[0 : magic_row.offset]
                     else:
-                        # We have no way to know where it will be in the file
                         scan_bytes = header
                     if re.search(magic_row.byte_match, scan_bytes):
                         new_matches.add(
@@ -198,7 +196,6 @@ def _identify_all(
                                 name=magic_row.name.split("###REGEX### ")[1],
                             )
                         )
-
                 else:
                     start = magic_row.offset
                     end = magic_row.offset + len(magic_row.byte_match)

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -163,9 +163,7 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
                     import re
 
                     if not magic_row.offset == 0:
-                        scan_bytes = header[
-                            0 : magic_row.offset
-                        ]  # We use .offset as amount of bytes from 0 to scan, saves opening whole file
+                        scan_bytes = header[0 : magic_row.offset]  # We use .offset as amount of bytes from 0 to scan, saves opening whole file
                     else:
                         scan_bytes = header  # We have no way to know where it will be in the file
                     if re.search(magic_row.byte_match, scan_bytes):
@@ -175,9 +173,7 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
                                 offset=magic_row.offset,
                                 extension=magic_row.extension,
                                 mime_type=magic_row.mime_type,
-                                name=magic_row.name.split("###REGEX### ")[
-                                    1
-                                ],  # Strips ###REGEX### trigger from name
+                                name=magic_row.name.split("###REGEX### ")[1],  # Strips ###REGEX### trigger from name
                             )
                         )
 


### PR DESCRIPTION
Could close #12, but likely not (skip to conclusion for why)

Based on trying to think of a way to help improve matches further (it's a great cure for my insomnia at night) I wanted to try adding a REGEX matcher into PureMagic. This should allow for higher confidence hits on files, especially those that share common markers such a `PK` and `PAK`. This may not be the definitive solution (I'll discuss why below) but it's a start towards making PureMagic more powerful.

## How it works:

1. Scan for regular magic bytes as normal
2. Find a matching entry inside the `multi-part` data 
3. Scan either a defined block size from the start of the file where we can be certain it's somewhere in that region, or scan the whole file (where we have no idea of a fixed point). 
4. Find a match and add to results list

Example test entries in the .json:
```
	"504b030414000600" : [
	  ["776f72642f646f63756d656e742e786d6c", 3000, ".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "###REGEX### MS Office Open XML Format Word Document"],
	  ["786c2f776f726b626f6f6b2e786d6c", 3000, ".xlsx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "###REGEX### Microsoft Office 2007+ Open XML Format Excel Document file"],
	  ["786c2f76626150726f6a6563742e62696e", 0, ".xlsm", "application/vnd.ms-excel.sheet.macroEnabled.12","###REGEX### Microsoft Excel - Macro-Enabled Workbook"]
	]
```
Both `.docx` and `.xlsx` have 3000 in the offset field, this is because we can be 99% certain the matching bytes will be within the first 3000 bytes of the file. However, `.xlsm` has a 0 as we know what we are looking for but it could be anywhere in the file. As all three of these examples are essentially .zip files we can cheat and just use path/filenames we are expecting in the archive. As the structure is mostly rigid, we can assume (and my tests show):

- `0x776f72642f646f63756d656e742e786d6c` / `word/document.xml` will be in the first 3000 bytes for `.docx`
- `0x786c2f776f726b626f6f6b2e786d6c` / `xl/workbook.xml` will be in the first 3000 bytes for `.xlsx`
- `0x786c2f76626150726f6a6563742e62696e` / `xl/vbaProject.bin` will be somewhere in a `.xlsm`, as it comes after the spreadsheet data we cannot predict a scan area.

## Implementation:
To save reinventing the wheel I have leveraged the existing `multi-part` system, it works for this concept and only required minimal changes to the code. In the .json, entries are treated as before with the only difference being the offset becomes a block size from byte zero to scan, or 0 if unknown, additionally we prefix the name with `###REGEX### ` (with a space) as a nice clear trigger that would not have any real world use. 

In the code if the trigger is found in the name it will REGEX, otherwise it will perform the normal string matching as before. I ran the code through BLACK so it looks a bit wacky in the layout but that's how it wants it to be.

## PROS:
This should improve anything, while using `.docx`, `.xlsx` and `.xlsm` for examples we could fingerprint similar `PK` based files.
- .jar = `0x4d4554412d494e462f4d414e49464553542e4d46` / `META-INF/MANIFEST.MF`
- .apk = `0x416e64726f69644d616e69666573742e786d6c` / `AndroidManifest.xml`
- .odt = `0x6d696d65747970656170706c69636174696f6e2f766e642e6f617369732e6f70656e646f63756d656e742e74657874` / `mimetypeapplication/vnd.oasis.opendocument.text` (This may be a fixed string, need to investigate further but for the purpose of conversation I'll include it for now)

## CONS:
While this will bring better results, there are some downsides/considerations:
- Memory size / Speed: Trying to regex a whole file could be an issue on low powered system, equally if the file is too big to read into memory in one go it will break something. This could be mitigated with some clever maths to read the file in overlapping chunks that fit within the memory, how to do that without relying on external libraries might need some sideways logic.
- Confidence scores: The issue we now face is how to ensure we have a clear winner, especially for `PK` based files. In testing I can now generate a lot of 0.8's but we need to possibly change the logic so the longest match always wins and is presented as first match, see examples in https://github.com/cdgriffith/puremagic/issues/12#issuecomment-2094122612. (Should be fixed by #66)
- Confidence clashes: This is slightly separate from the above, a lot of the `PK` based files have common roots and therefore share common files. `.jar` and `.apk` both contain `META-INF/MANIFEST.MF` so an `.apk` would likely give an equal score to a `.jar`. The same applies for `.xlsx` and `xlsm`, they both have `xl/workbook.xml` in their file structure. 
- Casing: This again applies mostly to `PK` based files, while it should be safe to assume that all files will always use the same case for filenames, it's entirely possible for them not to. For matching purposes, we may need to look at better fuzzy logic in the regex's to ensure that `META-INF/MANIFEST.MF`, `Meta-Inf/Manifest.Mf` and `meta-inf/manifest.mf` are all matchable.

## CONCLUSION:
This leads to this solution likely not being the definitive one but more a starting point, a rule-based system like @cdgriffith proposes is still the better path, for this. Along those lines a better solution could be:

- Perform initial magic.json match
- Check if a matching `504b030414000600.py` (PK) file lives inside a `definitions` folder
- Process the rules inside such as in this crude example:
```
If "META-INF/MANIFEST.MF" and "AndroidManifest.xml" it's an .apk
If "META-INF/MANIFEST.MF" and not "AndroidManifest.xml" it's an .jar
etc...
Collate results and send back to main.py
```
- Take those results, add to the string matches and sort the confidence list in order of longest byte match first, the .apk match would have three sets of bytes; PK, MANIFEST and ANDROID which would be a very long match, this should ensure we have a clearer winner.

Wow that was a lot of writing, especially as we'll likely not use this in the long run 🤣 Thoughts and suggestions?