### PR TITLE
2024-05-06 Fix Confidence sorting

### DIFF
--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -131,7 +131,7 @@ def _confidence(matches, ext=None) -> List[PureMagicWithConfidence]:
     if not results:
         raise PureError("Could not identify file")
 
-    return sorted(results, key=lambda x: x.confidence, reverse=True)
+    return sorted(results, key=lambda x: (x.confidence, x.byte_match), reverse=True)
 
 
 def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithConfidence]:
@@ -353,7 +353,7 @@ def magic_stream(stream, filename: Optional[Union[os.PathLike, str]] = None) -> 
         raise ValueError("Input was empty")
     ext = ext_from_filename(filename) if filename else None
     info = _identify_all(head, foot, ext)
-    info.sort(key=lambda x: (x.confidence,x.byte_match), reverse=True)
+    info.sort(key=lambda x: x.confidence, reverse=True)
     return info
 
 
@@ -389,4 +389,3 @@ def command_line_entry(*args):
 
 if __name__ == "__main__":
     command_line_entry()
-    

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -159,57 +159,33 @@ def _identify_all(header: bytes, footer: bytes, ext=None) -> List[PureMagicWithC
     for matched in matches:
         if matched.byte_match in multi_part_dict:
             for magic_row in multi_part_dict[matched.byte_match]:
-                if "###REGEX###" in magic_row.name:
-                    import re
-
-                    if not magic_row.offset == 0:
-                        scan_bytes = header[
-                            0 : magic_row.offset
-                        ]  # We use .offset as amount of bytes from 0 to scan, saves opening whole file
-                    else:
-                        scan_bytes = header  # We have no way to know where it will be in the file
-                    if re.search(magic_row.byte_match, scan_bytes):
+                start = magic_row.offset
+                end = magic_row.offset + len(magic_row.byte_match)
+                if magic_row.offset < 0:
+                    match_area = footer[start:end] if end != 0 else footer[start:]
+                    if match_area == magic_row.byte_match:
                         new_matches.add(
                             PureMagic(
                                 byte_match=matched.byte_match + magic_row.byte_match,
                                 offset=magic_row.offset,
                                 extension=magic_row.extension,
                                 mime_type=magic_row.mime_type,
-                                name=magic_row.name.split("###REGEX### ")[
-                                    1
-                                ],  # Strips ###REGEX### trigger from name
+                                name=magic_row.name,
                             )
                         )
-
                 else:
-                    start = magic_row.offset
-                    end = magic_row.offset + len(magic_row.byte_match)
-                    if magic_row.offset < 0:
-                        match_area = footer[start:end] if end != 0 else footer[start:]
-                        if match_area == magic_row.byte_match:
-                            new_matches.add(
-                                PureMagic(
-                                    byte_match=matched.byte_match
-                                    + magic_row.byte_match,
-                                    offset=magic_row.offset,
-                                    extension=magic_row.extension,
-                                    mime_type=magic_row.mime_type,
-                                    name=magic_row.name,
-                                )
+                    if end > len(header):
+                        continue
+                    if header[start:end] == magic_row.byte_match:
+                        new_matches.add(
+                            PureMagic(
+                                byte_match=header[matched.offset : end],
+                                offset=magic_row.offset,
+                                extension=magic_row.extension,
+                                mime_type=magic_row.mime_type,
+                                name=magic_row.name,
                             )
-                    else:
-                        if end > len(header):
-                            continue
-                        if header[start:end] == magic_row.byte_match:
-                            new_matches.add(
-                                PureMagic(
-                                    byte_match=header[matched.offset : end],
-                                    offset=magic_row.offset,
-                                    extension=magic_row.extension,
-                                    mime_type=magic_row.mime_type,
-                                    name=magic_row.name,
-                                )
-                            )
+                        )
 
     matches.extend(list(new_matches))
     return _confidence(matches, ext)

--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -353,7 +353,7 @@ def magic_stream(stream, filename: Optional[Union[os.PathLike, str]] = None) -> 
         raise ValueError("Input was empty")
     ext = ext_from_filename(filename) if filename else None
     info = _identify_all(head, foot, ext)
-    info.sort(key=lambda x: x.confidence, reverse=True)
+    info.sort(key=lambda x: (x.confidence,x.byte_match), reverse=True)
     return info
 
 
@@ -389,3 +389,4 @@ def command_line_entry(*args):
 
 if __name__ == "__main__":
     command_line_entry()
+    


### PR DESCRIPTION
While adding #65 one of the things that flagged up was that no matter how long the `byte_match` the winner was not the longest match. This quick one liner addresses that issue. Confidence is sorted by `confidence` then `byte_match`.

Before, Alternate match 2 should be the winner:
```
China tax introduction(edited1).docx
Most likely match:
Format:        MS Office Open XML Format Document
Confidence:    80.0%
Extension:     .docx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00'
Hex:           504b 0304 1400 0600
String:        PK

Alternate match #1
Format:        Microsoft Office 2007+ Open XML Format Document file
Confidence:    80.0%
Extension:     .xlsx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00'
Hex:           504b 0304 1400 0600
String:        PK

Alternate match #2
Format:        MS Office Open XML Format Word Document
Confidence:    80.0%
Extension:     .docx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00word/document.xml'
Hex:           504b 0304 1400 0600 776f 7264 2f64 6f63 756d 656e 742e 786d 6c
String:        PKword/document.xml

Alternate match #3
Format:        MS Office Open XML Format Document
Confidence:    40.0%
Extension:     .pptx
MIME:          application/vnd.openxmlformats-officedocument.presentationml.presentation
Offset:        0
Bytes Matched: b'PK\x03\x04'
Hex:           504b 0304
String:        PK

Alternate match #4
Format:        MS Office Open XML Format Document
Confidence:    40.0%
Extension:     .xlsx
MIME:          application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
Offset:        0
Bytes Matched: b'PK\x03\x04'
Hex:           504b 0304
String:        PK

Omitting other 20+ matches

```

Now it is! :
```
China tax introduction(edited1).docx
Most likely match:
Format:        MS Office Open XML Format Word Document
Confidence:    80.0%
Extension:     .docx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        3000
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00word/document.xml'
Hex:           504b 0304 1400 0600 776f 7264 2f64 6f63 756d 656e 742e 786d 6c
String:        PKword/document.xml

Alternate match #1
Format:        MS Office Open XML Format Document
Confidence:    80.0%
Extension:     .docx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00'
Hex:           504b 0304 1400 0600
String:        PK

Alternate match #2
Format:        Microsoft Excel - Macro-Enabled Workbook
Confidence:    80.0%
Extension:     .xlsm
MIME:          application/vnd.ms-excel.sheet.macroEnabled.12
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00'
Hex:           504b 0304 1400 0600
String:        PK

Alternate match #3
Format:        Microsoft Office 2007+ Open XML Format Document file
Confidence:    80.0%
Extension:     .xlsx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00'
Hex:           504b 0304 1400 0600
String:        PK

Alternate match #4
Format:        MS Office Open XML Format Document
Confidence:    40.0%
Extension:     .pptx
MIME:          application/vnd.openxmlformats-officedocument.presentationml.presentation
Offset:        0
Bytes Matched: b'PK\x03\x04'
Hex:           504b 0304
String:        PK

Omitting other 20+ matches
```

This will help in the future with really long matches if PureMagic adopts rules, for example using this `.xlsm`, Alternate Match 1 would be the better choice as the file matches the .vba aspect, however regular Excel wins as that has a slightly longer match, the Macro flavored version comes second. With a rules based system you could combine those together for a MEGA MATCH! of `b'PK\x03\x04\x14\x00\x06\x00xl/workbook.xmlxl/vbaProject.bin'` which should be unbeatable 😎:
```
ID-Generator-MACRO.xlsm
Most likely match:
Format:        Microsoft Office 2007+ Open XML Format Excel Document file
Confidence:    80.0%
Extension:     .xlsx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        3000
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00xl/workbook.xml'
Hex:           504b 0304 1400 0600 786c 2f77 6f72 6b62 6f6f 6b2e 786d 6c
String:        PKxl/workbook.xml

Alternate match #1
Format:        Microsoft Excel - Macro-Enabled Workbook
Confidence:    80.0%
Extension:     .xlsm
MIME:          application/vnd.ms-excel.sheet.macroEnabled.12
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00xl/vbaProject.bin'
Hex:           504b 0304 1400 0600 786c 2f76 6261 5072 6f6a 6563 742e 6269 6e
String:        PKxl/vbaProject.bin

Alternate match #2
Format:        MS Office Open XML Format Document
Confidence:    80.0%
Extension:     .docx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00'
Hex:           504b 0304 1400 0600
String:        PK

Alternate match #3
Format:        Microsoft Excel - Macro-Enabled Workbook
Confidence:    80.0%
Extension:     .xlsm
MIME:          application/vnd.ms-excel.sheet.macroEnabled.12
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00'
Hex:           504b 0304 1400 0600
String:        PK

Alternate match #4
Format:        Microsoft Office 2007+ Open XML Format Document file
Confidence:    80.0%
Extension:     .xlsx
MIME:          application/vnd.openxmlformats-officedocument.wordprocessingml.document
Offset:        0
Bytes Matched: b'PK\x03\x04\x14\x00\x06\x00'
Hex:           504b 0304 1400 0600
String:        PK

Omitting other 20+ matches
```