### PR TITLE
GitHub Actions: Test on Python 3.13 beta

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -24,6 +24,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
         coveralls || true
 
     - name: Check distribution log description
+      shell: bash
       run: |
         python setup.py sdist bdist_wheel
         twine check dist/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,16 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-
+        include:
+          - os: macos-latest
+            python-version: '3.13'
+          - os: windows-latest
+            python-version: '3.13'
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
The Python 3.13 release notes mention `puremagic` as one of the alternatives for `imghdr` which was removed from the Standard Library so let's ensure that its tests pass on Python 3.13 beta.

https://www.python.org/downloads/release/python-3130b1/

May raise `ModuleNotFoundError: No module named 'imghdr'` because Python 3.13 removes it from the Standard Library.
* https://docs.python.org/3/library/imghdr.html

> imghdr: use the projects [filetype](https://pypi.org/project/filetype/), [puremagic](https://pypi.org/project/puremagic/), or [python-magic](https://pypi.org/project/python-magic/) instead. (Contributed by Victor Stinner in [gh-104773](https://github.com/python/cpython/issues/104773).)

https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-dead-batteries-and-other-module-removals