### PR TITLE
Do not perform function call in argument defaults

### DIFF
--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -69,10 +69,10 @@ class PureError(LookupError):
 
 
 def _magic_data(
-    filename: os.PathLike | str = os.path.join(here, "magic_data.json"),
+    filename: os.PathLike | str | None = None,
 ) -> tuple[list[PureMagic], list[PureMagic], list[PureMagic], dict[bytes, list[PureMagic]]]:
     """Read the magic file"""
-    with open(filename, encoding="utf-8") as f:
+    with open(filename or os.path.join(here, "magic_data.json"), encoding="utf-8") as f:
         data = json.load(f)
     headers = sorted((_create_puremagic(x) for x in data["headers"]), key=lambda x: x.byte_match)
     footers = sorted((_create_puremagic(x) for x in data["footers"]), key=lambda x: x.byte_match)


### PR DESCRIPTION
___Any function call that's used in a default argument will only be performed once, at definition time.
The returned value will then be reused by all calls to the function, which can lead to unexpected behavior.___
* https://docs.astral.sh/ruff/rules/function-call-in-default-argument

% `ruff check --select=B008`
```
puremagic/main.py:68:41: B008 Do not perform function call `os.path.join` in argument defaults;
    instead, perform the call within the function, or read the default from a module-level singleton
    variable
Found 1 error.
```
% `ruff rule B008`
# function-call-in-default-argument (B008)

Derived from the **flake8-bugbear** linter.

## What it does
Checks for function calls in default function arguments.

## Why is this bad?
Any function call that's used in a default argument will only be performed
once, at definition time. The returned value will then be reused by all
calls to the function, which can lead to unexpected behaviour.

Calls can be marked as an exception to this rule with the
[`lint.flake8-bugbear.extend-immutable-calls`] configuration option.

Arguments with immutable type annotations will be ignored by this rule.
Types outside of the standard library can be marked as immutable with the
[`lint.flake8-bugbear.extend-immutable-calls`] configuration option as well.

## Example
```python
def create_list() -> list[int]:
    return [1, 2, 3]


def mutable_default(arg: list[int] = create_list()) -> list[int]:
    arg.append(4)
    return arg
```

Use instead:
```python
def better(arg: list[int] | None = None) -> list[int]:
    if arg is None:
        arg = create_list()

    arg.append(4)
    return arg
```

If the use of a singleton is intentional, assign the result call to a
module-level variable, and use that variable in the default argument:
```python
ERROR = ValueError("Hosts weren't successfully added")


def add_host(error: Exception = ERROR) -> None:
    ...
```

## Options
- `lint.flake8-bugbear.extend-immutable-calls`
