### PR TITLE
fix(dist): add py.typed to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email="chris@cdgriffith.com",
     description="Pure python implementation of magic file detection",
     long_description=long_description,
-    package_data={"puremagic": ["*.json"]},
+    package_data={"puremagic": ["*.json", "py.typed"]},
     packages=["puremagic"],
     include_package_data=True,
     platforms="any",


### PR DESCRIPTION
Fixes #89, by adding `py.typed` to `package_data`, this was validated by running locally the following commands:

```sh
$ pip wheel .
$ unzip -l puremagic-1.25-py3-none-any.whl
Archive:  puremagic-1.25-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      102  07-05-2024 13:59   puremagic/__init__.py
       90  07-05-2024 13:59   puremagic/__main__.py
   143189  07-05-2024 13:59   puremagic/magic_data.json
    15622  07-05-2024 13:59   puremagic/main.py
        0  07-05-2024 13:59   puremagic/py.typed
     1086  07-05-2024 14:02   puremagic-1.25.dist-info/LICENSE
     5854  07-05-2024 14:02   puremagic-1.25.dist-info/METADATA
       91  07-05-2024 14:02   puremagic-1.25.dist-info/WHEEL
       10  07-05-2024 14:02   puremagic-1.25.dist-info/top_level.txt
      775  07-05-2024 14:02   puremagic-1.25.dist-info/RECORD
---------                     -------
   166819                     10 files
```

Note how the `py.typed` file is now included in the generated wheel.