### PR TITLE
include py.typed in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include puremagic/*.json
+include puremagic/py.typed
 include LICENSE
 include AUTHORS.rst
 include CHANGELOG.md


### PR DESCRIPTION
Thanks for `puremagic`!

This continues #90 by ensuring `py.typed` is included in the sdist (it is not in the 1.26 tarball).