### PR TITLE
Improve PDF file detection, fix description

### DIFF
--- a/puremagic/magic_data.json
+++ b/puremagic/magic_data.json
@@ -20,7 +20,7 @@
     ["", 0, ".crt", "text/plain", "X.509 Certificate"],
     ["", 0, ".reg", "", "Windows Registry File"],
     ["", 0, ".md", "text/plain", "Markdown File"],
-    ["", 0, ".json", "application/json", "Markdown File"],
+    ["", 0, ".json", "application/json", "JSON File"],
     ["", 0, ".rst", "text/plain", "Restructured Text File"],
     ["", 0, ".cfg", "text/plain", "Configuration File"],
     ["", 0, ".flake8", "text/plain", "Flake 8 Configuration File"],

--- a/puremagic/magic_data.json
+++ b/puremagic/magic_data.json
@@ -28,6 +28,7 @@
     ["", 0, ".c", "text/x-csrc", "C Code File"],
     ["", 0, ".cc", "text/x-csrc", "C Code File"],
     ["", 0, ".h", "text/x-csrc", "C Header File"],
+    ["", 0, ".pdf", "application/pdf", "Adobe Portable Document Format file"],
     ["", 0, ".stl", "model/stl", "stereolithography CAD software"],
     ["", 0, ".srt", "application/x-subrip", "SubRip subtitles"],
     ["", 0, ".obj", "", "Relocatable object code"],

--- a/puremagic/magic_data.json
+++ b/puremagic/magic_data.json
@@ -745,6 +745,7 @@
     ["000100004d534953414d204461746162617365", 0, ".mny", "application/x-msmoney", "Microsoft Money file"],
     ["000100005374616e64617264204a6574204442", 0, ".mdb", "application/x-msaccess", "Microsoft Access file"],
     ["25504446", 0, ".pdf", "application/pdf", "Adobe Portable Document Format file"],
+    ["0d0a25504446", 0, ".pdf", "application/pdf", "Adobe Portable Document Format file"],
     ["a0461df0", 512, ".ppt", "application/vnd.ms-powerpoint", "Microsoft Office PowerPoint Presentation file"],
     ["cf11e0a1b11ae100", 0, ".doc", "application/msword", "Perfect Office Document file"],
     ["d0cf11e0a1b11ae1", 0, ".doc", "application/msword", "Microsoft Office Document file"],


### PR DESCRIPTION
Hi! 

There is at least one system out in the wild that produces pdf files which start with a CRLF.

I added it as an extra entry.

Though from my testing, you can have any junk in front of the file as long as at some point you encounter the `%PDF-` string so a proper fix would be to look for the sequence of bytes/characters.

Anyways, stay safe out there!