### PR TITLE
Halt on non-regular files like /dev/zero and /dev/random

### DIFF
--- a/puremagic/main.py
+++ b/puremagic/main.py
@@ -218,6 +218,8 @@ def _magic(header: bytes, footer: bytes, mime: bool, ext=None, filename=None) ->
 
 def _file_details(filename: os.PathLike | str) -> tuple[bytes, bytes]:
     """Grab the start and end of the file"""
+    if not os.path.isfile(filename):
+        raise PureError("Not a regular file")
     with open(filename, "rb") as fin:
         head = fin.read(max_head)
         try:


### PR DESCRIPTION
Non regular files can not be trusted to be bounded. For example /dev/zero is infinitely large. Obtaining the footer of said file will never complete because file.seek() will never return. Instead it will fill up your memory until your process is targeted by the OOM killer.

Thanks for the package, very useful! However yesterday our production server got killed by the kernel's Out-Of-Memory killer. Turns out a database record referred to /dev/zero (where it should have been set to /dev/null).  Puremagic quickly ate all memory available on our server and then got shot in the face by OOM killer. ;-)

To reproduce on Linux: python3 -m puremagic /dev/zero

Thanks!